### PR TITLE
Added exception tag for mapmaker

### DIFF
--- a/src/main/java/online/meinkraft/customvillagertrades/listener/VillagerAcquireTradeListener.java
+++ b/src/main/java/online/meinkraft/customvillagertrades/listener/VillagerAcquireTradeListener.java
@@ -2,6 +2,7 @@ package online.meinkraft.customvillagertrades.listener;
 
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import online.meinkraft.customvillagertrades.trade.CustomTradeManager;
 import online.meinkraft.customvillagertrades.villager.VillagerData;
@@ -36,6 +37,8 @@ public class VillagerAcquireTradeListener implements Listener {
 
         Villager villager = (Villager) event.getEntity();
 
+        Set<String> tagSet = villager.getScoreboardTags(); // [Cruxien]: Potential addition to allow exceptions to the Disabled Vanilla Professions.
+
         // don't allow nitwits or villagers with no profession to acquire trades
         if(
             villager.getProfession().equals(Villager.Profession.NONE) ||
@@ -63,7 +66,7 @@ public class VillagerAcquireTradeListener implements Listener {
             // don't allow villager to acquire vanilla trade if they are disabled
             if(
                 !plugin.isVanillaTradesAllowed() ||
-                plugin.isVanillaTradesDisabledForProfession(villager.getProfession())
+                (plugin.isVanillaTradesDisabledForProfession(villager.getProfession()) && !tagSet.contains("cvt_trade_override"))
             ) {
                 event.setCancelled(true);
             }
@@ -75,9 +78,11 @@ public class VillagerAcquireTradeListener implements Listener {
             if(trade != null) {
                 // chance of not getting the trade (if vanilla trades aren't disabled)
                 if(
-                    plugin.isVanillaTradesAllowed() && 
+                    (plugin.isVanillaTradesAllowed() && 
                     !plugin.isVanillaTradesDisabledForProfession(villager.getProfession()) &&
-                    rand.nextDouble() > trade.getChance()
+                    rand.nextDouble() > trade.getChance()) || 
+                    tagSet.contains("cvt_trade_override") // [Cruxien] Overrides those conditions if it has the tag. 
+                    // Allows admins to include "cvt_trade_override" in the tags to allow mapmakers to use villager codes with custom trades without the plugin mistaking them for normal ones
                 ) {
                     // keep vanilla trade
                     event.setRecipe(event.getRecipe());

--- a/src/main/java/online/meinkraft/customvillagertrades/trade/CustomTradeManager.java
+++ b/src/main/java/online/meinkraft/customvillagertrades/trade/CustomTradeManager.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -98,6 +99,7 @@ public class CustomTradeManager {
     public void refreshTrades(Villager villager, Player player) {
 
         Merchant merchant = (Merchant) villager;
+        Set<String> tagSet = villager.getScoreboardTags(); // [Cruxien]: Potential addition to allow exceptions to the Disabled Vanilla Professions.
 
         VillagerManager villagerManager = plugin.getVillagerManager();
         VillagerData villagerData = villagerManager.loadVillagerData(villager);
@@ -169,14 +171,17 @@ public class CustomTradeManager {
             }
             else if(
                 plugin.isVanillaTradesAllowed() &&
-                !plugin.isVanillaTradesDisabledForProfession(villager.getProfession())
+                (!plugin.isVanillaTradesDisabledForProfession(villager.getProfession()) || (plugin.isVanillaTradesDisabledForProfession(villager.getProfession()) && tagSet.contains("cvt_trade_override"))) // [Cruxien]: Potential addition to allow exceptions to the Disabled Vanilla Professions. 
             ) {
                 newRecipes.add(oldRecipes.get(index));
             }
         }
 
-        merchant.setRecipes(newRecipes);
-        villagerManager.saveVillagerData(villagerData);
+        if (!tagSet.contains("cvt_trade_override")) { // [Cruxien]: Hopefully allows the individual villager to bypass this entirely and use the trades already in its data
+        	merchant.setRecipes(newRecipes);
+        	villagerManager.saveVillagerData(villagerData);
+        }
+        
 
     }
 


### PR DESCRIPTION
I'm no Github expert, so forgive me if this is a little messy;
Decided to save you some time and add the enhancement myself! My Java is a little rusty, but I got there in the end. 
(Closes #16 )

- Checks if villager has scoreboard tag "cvt_trade_override"; If so, uses the vanilla trades regardless of disabled professions list
- Allows villagers with predetermined trades in nbt to function as expected in custom map / server scenarios
- Custom (NBT) trades are still removed at present if !plugin.isVanillaTradesAllowed(); Leaving it to Reldeam's discretion as to how that interacts